### PR TITLE
Add additional examples of directed rounding

### DIFF
--- a/xml/System/MidpointRounding.xml
+++ b/xml/System/MidpointRounding.xml
@@ -98,13 +98,15 @@ The following table demonstrates the results of rounding some negative and posit
   
 |Original number|ToNegativeInfinity|ToPositiveInfinity|ToZero|  
 |---------------------|------------------|------------|------|  
+|3.5|3|4|3|  
 |2.8|2|3|2|  
 |2.5|2|3|2|  
 |2.1|2|3|2|  
 |-2.1|-3|-2|-2|  
 |-2.5|-3|-2|-2|  
 |-2.8|-3|-2|-2|  
-  
+|-3.5|-4|-3|-3|  
+
 ## Examples
 
 The following example demonstrates the <xref:System.Math.Round%2A?displayProperty=nameWithType> method in conjunction with the `MidpointRounding` enumeration:


### PR DESCRIPTION
## Summary

Added additional examples for directed rounding.
Specifically, examples for 3.5 which exist for Round to nearest, but were missing in directed rounding section.

Fixes (#6744)
<!-- If the issue is found in <https://github.com/dotnet/docs, this takes the form "Fixes dotnet/docs#Issue_Number" -->

